### PR TITLE
Removed "Emerald Block" from the "Infinity Catalyst"

### DIFF
--- a/src/main/resources/assets/avaritia/avaritia_recipes/extreme/items/infinity_catalyst.json
+++ b/src/main/resources/assets/avaritia/avaritia_recipes/extreme/items/infinity_catalyst.json
@@ -7,10 +7,6 @@
 	},
 	"ingredients": [
 		{
-			"type": "forge:ore_dict",
-			"ore": "blockEmerald"
-		},
-		{
 			"type": "minecraft:item",
 			"item": "#diamond_lattice"
 		},


### PR DESCRIPTION
Removed "Emerald Block" from the "Infinity Catalyst" recipe because it already contains the corresponding singularity