### PR TITLE
Bugfix for singularity cost config

### DIFF
--- a/src/main/java/morph/avaritia/handler/ConfigHandler.java
+++ b/src/main/java/morph/avaritia/handler/ConfigHandler.java
@@ -182,6 +182,7 @@ public class ConfigHandler {
         comment = "Added to the existing multiplier to make prices more expensive or cheaper. Can be negative.";
         langKey = "avaritia:config.balance.multiplier";
 
+        prop = config.get(category, "Cost Multiplier", 0);
         prop.setComment(comment);
         prop.setLanguageKey(langKey);
         prop.setRequiresMcRestart(true);


### PR DESCRIPTION
Fixed an oversight that caused the both the modifier and multiplier for the singularity recipe costs to be set from just the modifier.