### PR TITLE
Change shader version from 130 to 120 to be compatible with MacOS

### DIFF
--- a/src/main/resources/assets/avaritia/shader/cosmic.frag
+++ b/src/main/resources/assets/avaritia/shader/cosmic.frag
@@ -1,4 +1,4 @@
-#version 130
+#version 120
 
 #define M_PI 3.1415926535897932384626433832795
 
@@ -20,6 +20,10 @@ uniform float opacity;
 uniform mat2 cosmicuvs[cosmiccount];
 
 varying vec3 position;
+
+float rand2d(vec2 x) {
+    return fract(sin(dot(x, vec2(12.9898, 78.233))) * 43758.5453123);
+}
 
 mat4 rotationMatrix(vec3 axis, float angle)
 {
@@ -101,8 +105,7 @@ void main (void)
 		int tv = int(mod(floor(v*uvtiles),uvtiles)); 
 		
 		// get pseudorandom variants
-		int position = ((1777541 * tu) + (7649689 * tv) + (3612703 * (i+31)) + 1723609 ) ^ 50943779;
-		int symbol = int(mod(position, cosmicoutof));
+		int symbol = int(rand2d(vec2(tu, tv + i * 10.0)) * cosmicoutof);
 		int rotation = int(mod(pow(tu,float(tv)) + tu + 3 + tv*i, 8));
 		bool flip = false;
 		if (rotation >= 4) {

--- a/src/main/resources/assets/avaritia/shader/cosmic.frag
+++ b/src/main/resources/assets/avaritia/shader/cosmic.frag
@@ -22,7 +22,7 @@ uniform mat2 cosmicuvs[cosmiccount];
 varying vec3 position;
 
 float rand2d(vec2 x) {
-    return fract(sin(dot(x, vec2(12.9898, 78.233))) * 43758.5453123);
+    return fract(sin(mod(dot(x, vec2(12.9898, 78.233)), 3.14)) * 43758.5453);
 }
 
 mat4 rotationMatrix(vec3 axis, float angle)

--- a/src/main/resources/assets/avaritia/shader/cosmic.frag
+++ b/src/main/resources/assets/avaritia/shader/cosmic.frag
@@ -77,9 +77,9 @@ void main (void)
 	
 		// get semi-random stuff
 		int j = i + 7;
-		float rand1 = (j * j * 4321 + j * 8) * 2.0F;
+		float rand1 = (j * j * 4321 + j * 8) * 2.0;
 		int k = j + 1;
-		float rand2 = (k * k * k * 239 + k * 37) * 3.6F;
+		float rand2 = (k * k * k * 239 + k * 37) * 3.6;
 		float rand3 = rand1 * 347.4 + rand2 * 63.4;
 		
 		// random rotation matrix by random rotation around random axis


### PR DESCRIPTION
The fragment shader used for a lot of the infinity gear is marked with a GLSL version of 130 instead of 120 like most of the other shaders used in minecraft. This is fine on most operating systems, however on MacOS you can't specify a GLSL version that's different than the OpenGL version used to create the window (see [this question](https://stackoverflow.com/questions/20264814) on Stack Overflow for details). Because of this the shader doesn't compile on MacOS, which is bug that has been reported on the repo for the 1.7.10 version of Avaritia but no one seemed to know how to fix it. SpitefulFox/Avaritia#9

As was mentioned in that other issue, you can't just change the version from 130 to 120 because a bitwise XOR is used for randomizing the symbols and bitwise operators are only available in GLSL version 130. However there are many other RNG algorithms than the one that's used in the shader, and in this pull request I've changed the symbol randomization to use an RNG that doesn't require bitwise operators. I've also removed several `F` suffixes on numbers that were causing the shader to not compile on MacOS.

Here's a screenshot of what the sword of the cosmos looks like using the default shader on MacOS:
![2020-01-18_10 16 35](https://user-images.githubusercontent.com/13701628/72667368-cc398280-39e0-11ea-9150-b734aab4ae3a.png)
With this error in the log:
```
[10:11:29] [main/INFO] [STDERR]: [morph.avaritia.client.render.shader.ShaderHelper:createShader:130]: java.lang.RuntimeException: Error creating shader "/assets/avaritia/shader/cosmic.frag": ERROR: 0:1: '' :  version '130' is not supported
ERROR: 0:76: 'F' : syntax error: syntax error

[10:11:29] [main/INFO] [STDERR]: [morph.avaritia.client.render.shader.ShaderHelper:createShader:130]: 	at morph.avaritia.client.render.shader.ShaderHelper.createShader(ShaderHelper.java:124)
[10:11:29] [main/INFO] [STDERR]: [morph.avaritia.client.render.shader.ShaderHelper:createShader:130]: 	at morph.avaritia.client.render.shader.ShaderHelper.createProgram(ShaderHelper.java:81)
[10:11:29] [main/INFO] [STDERR]: [morph.avaritia.client.render.shader.ShaderHelper:createShader:130]: 	at morph.avaritia.client.render.shader.ShaderHelper.initShaders(ShaderHelper.java:37)
[10:11:29] [main/INFO] [STDERR]: [morph.avaritia.client.render.shader.ShaderHelper:createShader:130]: 	at morph.avaritia.proxy.ProxyClient.preInit(ProxyClient.java:75)
[10:11:29] [main/INFO] [STDERR]: [morph.avaritia.client.render.shader.ShaderHelper:createShader:130]: 	at morph.avaritia.Avaritia.preInit(Avaritia.java:46)
...
```

With my edit of the shader:
![2020-01-18_10 22 18](https://user-images.githubusercontent.com/13701628/72667385-11f64b00-39e1-11ea-8125-7fd2dda97f22.png)
And no errors in the log.

This change shouldn't affect anybody on other operating systems, all it should do is increase compatibility. The only thing is I'm not sure about is whether my RNG will produce equivalent results to the original RNG, so let me know if the infinity gear looks wrong after this change.